### PR TITLE
Adapter jlabrec

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ in the following languages with plans to support more languages in the future:
 
 ## Java Design Patterns
 The following design patterns have been implemented in Java:
+- Adapter
 - Decorator
 - Iterator
+
 
 ## Python
 This section is under construction. More to come at a later date.

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'java'
 }
 
+apply plugin: 'application'
+mainClassName = 'Main'
+
 group 'org.example'
 version '1.0-SNAPSHOT'
 

--- a/java/src/main/java/Main.java
+++ b/java/src/main/java/Main.java
@@ -1,7 +1,15 @@
 import adapter.*;
-public class Main {
 
-    private static void adapterDemo() {
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+public class Main {
+    // List of valid args
+    private static List<String> allArgs = Arrays.asList("-adapter");
+
+
+    private static void runAdapter() {
         System.out.println("You've got an Iphone 5 and wanna listen to music with your 3.5 mm headphones. Easy");
         Headphones headphones = new Headphones();
         headphones.listen();
@@ -13,11 +21,46 @@ public class Main {
 
         System.out.println("Luckily, we know we can just use an adapter, to adapt to this new interface");
         headphones.iphone = new USBAdapter();
+        System.out.println("\n\nAdapter applied, lets listen to music:");
         headphones.listen();
     }
 
-    public static void main(String[] args){
-        adapterDemo();
+    private static boolean validateArgs(String[] pArgs) {
+        // Validate args
+        StringBuilder badArgs = new StringBuilder();
+        for (String arg: pArgs) {
+            if (!allArgs.contains(arg)) {
+                badArgs.append(" ");
+                badArgs.append(arg);
+            }
+
+        }
+        // invalid args
+        if (badArgs.length() > 0) {
+            System.out.printf("Unknown command-line option(s):%s\n", badArgs.toString());
+            // TODO: Add help text that informs usage of cli args
+
+            System.exit(0);
+        }
+        return true;
+    }
+
+    public static void main(String[] pArgs) {
+        // TODO: Refactor as abstracted cli runtime config
+        List<String> cliArgs = new LinkedList<>(Arrays.asList(pArgs));
+        validateArgs(pArgs);
+
+        // Default - no params, run all
+        if (cliArgs.isEmpty()) {
+
+            cliArgs.addAll(allArgs);
+        }
+
+        // execute examples
+        if (cliArgs.contains("-adapter")){
+            runAdapter();
+        }
+
     }
 
 }

--- a/java/src/main/java/Main.java
+++ b/java/src/main/java/Main.java
@@ -1,0 +1,23 @@
+import adapter.*;
+public class Main {
+
+    private static void adapterDemo() {
+        System.out.println("You've got an Iphone 5 and wanna listen to music with your 3.5 mm headphones. Easy");
+        Headphones headphones = new Headphones();
+        headphones.listen();
+
+        System.out.println("\n\nBut now you've upgraded your phone to the Iphone 10. You wanna listen to music");
+        System.out.println("Wait... The iphone 10 uses a different interface for headphone connections, it uses USB-C");
+        System.out.println("We know Apple isn't exactly friendly to popping open the device and adjusting the hardware" +
+                "so what should we do");
+
+        System.out.println("Luckily, we know we can just use an adapter, to adapt to this new interface");
+        headphones.iphone = new USBAdapter();
+        headphones.listen();
+    }
+
+    public static void main(String[] args){
+        adapterDemo();
+    }
+
+}

--- a/java/src/main/java/adapter/AudioJackIphone.java
+++ b/java/src/main/java/adapter/AudioJackIphone.java
@@ -1,0 +1,13 @@
+package adapter;
+
+/**
+ * Interface for devices that conform to the 3.5mm standard audio jack, such as earlier Iphone 1-5's
+ */
+public interface AudioJackIphone {
+
+    /**
+     * Method for behaviour when 3.5mm headphones are plugged in.
+     */
+    public void audioPlugin();
+
+}

--- a/java/src/main/java/adapter/Headphones.java
+++ b/java/src/main/java/adapter/Headphones.java
@@ -1,0 +1,23 @@
+package adapter;
+
+/**
+ * Headphones class are used to listen to music on a phone. Supports listening on devices that subscribe to the
+ * AudioJackIphone standard.
+ */
+public class Headphones {
+    public AudioJackIphone iphone;
+
+    public Headphones() {
+        this.iphone = new Iphone5();
+    }
+
+    /**
+     * Listen to music on your iphone
+     */
+    public void listen(){
+        this.iphone.audioPlugin();
+    }
+
+
+
+}

--- a/java/src/main/java/adapter/Iphone10.java
+++ b/java/src/main/java/adapter/Iphone10.java
@@ -1,0 +1,16 @@
+package adapter;
+
+/**
+ * Iphone10 Subscribes to the new standard of USB-C ports for connections. Sadly, 3.5mm connections are no longer supported
+ * on this newer technology.
+ */
+public class Iphone10 implements USBIphone{
+
+    /**
+     * usbPlugin allows for playing music through the devices USB-C port.
+     */
+    @Override
+    public void usbPlugin() {
+        System.out.println("Now listening to music through the power of USB-C!");
+    }
+}

--- a/java/src/main/java/adapter/Iphone5.java
+++ b/java/src/main/java/adapter/Iphone5.java
@@ -1,0 +1,16 @@
+package adapter;
+
+/**
+ * Class Iphone 5 implements the AudioJackIphone interface, and allows for connecting headphones that are 3.5mm standard
+ * and listening to some music.
+ */
+public class Iphone5 implements AudioJackIphone {
+
+    /**
+     * audioPlugin() Plays music when headphones are plugged in.
+     */
+    @Override
+    public void audioPlugin() {
+        System.out.println("Now Listening to music through 3.5mm Audio jack!");
+    }
+}

--- a/java/src/main/java/adapter/README.md
+++ b/java/src/main/java/adapter/README.md
@@ -1,0 +1,47 @@
+# Adapter Design Pattern
+
+### Description: 
+
+The adapter design pattern can be used to convert the interface of a class into another interface 
+clients expect. The adapter lets classes work together which otherwise could not because of
+incompatible interfaces. 
+
+### The Problem
+
+This example uses the semi-recent change in cellphones from having the standard 3.5mm 
+audio output port, to just having a USB type C port. Understandably this caused some issues. Now you
+have this fancy new phone, but your only headphones are not compatible with it. 
+
+### The Solution
+
+We make an adapter! In the code there is an Iphone5 class which subscribes to the contract
+present in the AudioJackIphone. This class represent your old phone, which your headphones work
+fine with. However, the Iphone10 class subscribes to the USBIphone contract, and is incompatible
+with your headphones. To make our headphones compatible with the new phone, we make an adapter, USBAdapter,
+that subscribes to the AudioJackIphone interface, and wraps(contains) an instance of a USBIphone 
+object. Now when we call `listen()` on our headphones, in turn calling the `audioPlugIn()` method 
+on it's instance of AudioJackIphone, the USBAdapter can now call the correct method in the Iphone10 
+class, and we have sweet beautiful music. 
+
+
+### Conclusion and Take Aways
+
+While this is a simple example, and we could have just bought(read made a USBC Headphone class)
+this wont always be the case. The adapter pattern can be used to adapt much more than a single method
+of a class simple class, and in fact the adapter pattern can be used to adapt to multiple 
+classes. 
+
+The adapter pattern is used to adapt a class you want to use, to make it fit an interface
+it does not already conform to. When using the adapter pattern, there should be no need
+to change the underlying behaviour of the class you're adapting. 
+
+
+# Resources
+
+[Christopher Okhravi's Adapter Video](https://www.youtube.com/watch?v=2PKQtcJjYvc)
+
+[DZone page on the Adapter Pattern](https://dzone.com/articles/adapter-design-pattern-in-java)
+
+[Gang of Four Desgn Patterns Book](https://www.amazon.com/Design-Patterns-Object-Oriented-Addison-Wesley-Professional-ebook/dp/B000SEIBB8)
+
+[Head First! Design Patterns](https://www.amazon.com/Head-First-Design-Patterns-Brain-Friendly/dp/0596007124)

--- a/java/src/main/java/adapter/USBAdapter.java
+++ b/java/src/main/java/adapter/USBAdapter.java
@@ -1,0 +1,22 @@
+package adapter;
+
+/**
+ * USB Adapter is an adapter for 3.5mm headphones to be used on phones that subscribe to the USB-C standard.
+ */
+public class USBAdapter implements AudioJackIphone{
+
+    USBIphone iphone;
+
+    /**
+     * Here more logic could be employed to allow for more than the IPhone10 to be implemented, but this works for this
+     * simple example.
+     */
+    public USBAdapter() {
+        this.iphone = new Iphone10();
+    }
+
+    @Override
+    public void audioPlugin() {
+        this.iphone.usbPlugin();
+    }
+}

--- a/java/src/main/java/adapter/USBIphone.java
+++ b/java/src/main/java/adapter/USBIphone.java
@@ -1,0 +1,12 @@
+package adapter;
+
+/**
+ * Interface for newer iphones which subscribe to the USB-C standard port.
+ */
+public interface USBIphone {
+
+    /**
+     * Plug in a usb-c device!
+     */
+    public void usbPlugin();
+}


### PR DESCRIPTION
PR adds an example of the [Adapter Pattern](https://www.tutorialspoint.com/design_pattern/adapter_pattern.htm) to the project. 

Changes the gradle build file to allow for directly running the examples via the `gradle run` task, as well as adds a demo of the adapter pattern to the main script. CLI Args parsing and branching between which pattern is run is borrowed from @dswelbor 's implementation of main on the DEVPM-38-JavaExamples branch. 

- [X] code compiles?
- [X] code follows modern code style guidelines?
- [X] comments are present as needed?
- [X] variables have appropriate names?
- [X] readme updated?


To Test: 

1. navigate to `designpattern-demo/java` 
2. run `gradle run --args="-adapter" --quiet` 